### PR TITLE
Fix Insert/Parse TODOs

### DIFF
--- a/robotcontrollerclient/src/control.cpp
+++ b/robotcontrollerclient/src/control.cpp
@@ -911,10 +911,10 @@ void robotList() {
  * @return void
  * */
 void displayVictorInfo(VictorInfoFrame* victorInfoFrame, uint8_t* headMessage) {
-	const auto deviceId = parseType<int>((uint8_t*)&headMessage[1], 4);
-	const auto busVoltage = parseType<float>((uint8_t*)&headMessage[5], 4);
-	const auto outputVoltage = parseType<float>((uint8_t*)&headMessage[9], 4);
-	const auto outputPercent = parseType<float>((uint8_t*)&headMessage[13], 4);
+	const auto deviceId = parseType<int32_t>(&headMessage[1], 4);
+	const auto busVoltage = parseType<float>(&headMessage[5], 4);
+	const auto outputVoltage = parseType<float>(&headMessage[9], 4);
+	const auto outputPercent = parseType<float>(&headMessage[13], 4);
 	victorInfoFrame->setItem("Device ID", deviceId);
 	victorInfoFrame->setItem("Bus Voltage", busVoltage);
 	victorInfoFrame->setItem("Output Voltage", outputVoltage);
@@ -931,17 +931,17 @@ void displayVictorInfo(VictorInfoFrame* victorInfoFrame, uint8_t* headMessage) {
  * @return void
  * */
 void displayTalonInfo(TalonInfoFrame* talonInfoFrame, uint8_t* headMessage) {
-	const auto deviceId = parseType<int>((uint8_t*)&headMessage[1], 4);
-	const auto busVoltage = parseType<float>((uint8_t*)&headMessage[5], 4);
-	const auto outputCurrent = parseType<float>((uint8_t*)&headMessage[9], 4);
-	const auto outputVoltage = parseType<float>((uint8_t*)&headMessage[13], 4);
-	const auto outputPercent = parseType<float>((uint8_t*)&headMessage[17], 4);
-	const auto temperature = parseType<float>((uint8_t*)&headMessage[21], 4);
-	const auto sensorPosition = parseType<int>((uint8_t*)&headMessage[25], 4);
-	const auto sensorVelocity = parseType<int>((uint8_t*)&headMessage[29], 4);
-	const auto closedLoopError = parseType<int>((uint8_t*)&headMessage[33], 4);
-	const auto integralAccumulator = parseType<int>((uint8_t*)&headMessage[37], 4);
-	const auto errorDerivative = parseType<int>((uint8_t*)&headMessage[41], 4);
+	const auto deviceId = parseType<int32_t>(&headMessage[1], 4);
+	const auto busVoltage = parseType<float>(&headMessage[5], 4);
+	const auto outputCurrent = parseType<float>(&headMessage[9], 4);
+	const auto outputVoltage = parseType<float>(&headMessage[13], 4);
+	const auto outputPercent = parseType<float>(&headMessage[17], 4);
+	const auto temperature = parseType<float>(&headMessage[21], 4);
+	const auto sensorPosition = parseType<int32_t>(&headMessage[25], 4);
+	const auto sensorVelocity = parseType<int32_t>(&headMessage[29], 4);
+	const auto closedLoopError = parseType<int32_t>(&headMessage[33], 4);
+	const auto integralAccumulator = parseType<int32_t>(&headMessage[37], 4);
+	const auto errorDerivative = parseType<int32_t>(&headMessage[41], 4);
 	talonInfoFrame->setItem("Device ID", deviceId);
 	talonInfoFrame->setItem("Bus Voltage", busVoltage);
 	talonInfoFrame->setItem("Output Current", outputCurrent);
@@ -1063,12 +1063,12 @@ int main(int argc, char** argv) {
 			switch(command) {
 				case COMMAND_TO_CLIENT_POWER_DISTRIBUTION_PANEL: {
 					// Display voltage
-					const auto voltage = parseType<float>((uint8_t*)&headMessage[1], 4);
+					const auto voltage = parseType<float>(&headMessage[1], 4);
 					voltageLabel->set_label(std::to_string(voltage).c_str());
 
 					// Display Currents
 					for(size_t index = 0; index < numCurrents; index++) {
-						const auto current = parseType<float>((uint8_t*)&headMessage[5 + index * sizeof(float)], 4);
+						const auto current = parseType<float>(&headMessage[5 + index * sizeof(float)], 4);
 						currentLabels[index]->set_label(std::to_string(current).c_str());
 					}
 				} break;

--- a/robotcontrollerclient/src/control.cpp
+++ b/robotcontrollerclient/src/control.cpp
@@ -575,14 +575,14 @@ void setupGui(const Glib::RefPtr<Gtk::Application>& application) {
 
 	// Silent Run Button
 	const auto silentRunButton = ButtonFactory("Silent Running")
-							   .addClickedCallback<std::function<typeof(silentRun)>>(silentRun)
-							   .build();
+									 .addClickedCallback<std::function<typeof(silentRun)>>(silentRun)
+									 .build();
 
 	// Shutdown Robot Button
 	const auto shutdownCallback = [] { return shutdownDialog(window); };
 	const auto shutdownRobotButton = ButtonFactory("Shutdown Robot")
-								   .addClickedCallback<typeof(shutdownCallback)>(shutdownCallback)
-								   .build();
+										 .addClickedCallback<typeof(shutdownCallback)>(shutdownCallback)
+										 .build();
 
 	// Power Distribution Frame
 	const auto powerDistributionPanelFrame = Gtk::manage(new Gtk::Frame("Power Distribution Panel"));
@@ -596,9 +596,9 @@ void setupGui(const Glib::RefPtr<Gtk::Application>& application) {
 
 	// Power Boxes
 	const auto voltageBox = BoxFactory(Gtk::ORIENTATION_HORIZONTAL)
-						  .addFrontLabel("Voltage:")
-						  .packEnd(voltageLabel)
-						  .build();
+								.addFrontLabel("Voltage:")
+								.packEnd(voltageLabel)
+								.build();
 
 	Gtk::Box* currentBoxes[numCurrents];
 	for(size_t i = 0; i < numCurrents; i++) {
@@ -631,22 +631,22 @@ void setupGui(const Glib::RefPtr<Gtk::Application>& application) {
 
 	// Remote Control Box
 	const auto remoteControlBox = BoxFactory(Gtk::ORIENTATION_HORIZONTAL)
-								.addWidget(shutdownRobotButton)
-								.build();
+									  .addWidget(shutdownRobotButton)
+									  .build();
 
 	// State Box
 	const auto stateBox = BoxFactory(Gtk::ORIENTATION_HORIZONTAL)
-						.addWidget(silentRunButton)
-						.addWidget(modeLabel)
-						.addWidget(controlModeLabel)
-						.build();
+							  .addWidget(silentRunButton)
+							  .addWidget(modeLabel)
+							  .addWidget(controlModeLabel)
+							  .build();
 	// Connect Box
 	const auto connectBox = BoxFactory(Gtk::ORIENTATION_HORIZONTAL, 5)
-						  .addWidget(ipAddressLabel)
-						  .addWidget(ipAddressEntry)
-						  .addWidget(connectButton)
-						  .addWidget(connectionStatusLabel)
-						  .build();
+								.addWidget(ipAddressLabel)
+								.addWidget(ipAddressEntry)
+								.addWidget(connectButton)
+								.addWidget(connectionStatusLabel)
+								.build();
 
 	// Victor 1 Box
 	auto victor1BoxFactory = BoxFactory(Gtk::ORIENTATION_VERTICAL);
@@ -657,10 +657,10 @@ void setupGui(const Glib::RefPtr<Gtk::Application>& application) {
 
 	// Controls Right Box
 	const auto controlsRightBox = BoxFactory(Gtk::ORIENTATION_VERTICAL, 5)
-								.addWidget(connectBox)
-								.addWidget(stateBox)
-								.addWidget(remoteControlBox)
-								.build();
+									  .addWidget(connectBox)
+									  .addWidget(stateBox)
+									  .addWidget(remoteControlBox)
+									  .build();
 
 	// Talon Box
 	auto talonBoxFactory = BoxFactory(Gtk::ORIENTATION_VERTICAL);
@@ -671,21 +671,21 @@ void setupGui(const Glib::RefPtr<Gtk::Application>& application) {
 
 	// Controls Box
 	const auto controlsBox = BoxFactory(Gtk::ORIENTATION_HORIZONTAL, 5)
-						   .addWidget(scrolledList)
-						   .addWidget(controlsRightBox)
-						   .build();
+								 .addWidget(scrolledList)
+								 .addWidget(controlsRightBox)
+								 .build();
 
 	// Sensor Box
 	const auto sensorBox = BoxFactory(Gtk::ORIENTATION_HORIZONTAL)
-						 .addWidget(powerDistributionPanelFrame)
-						 .addWidget(talonBox)
-						 .addWidget(victor1Box)
-						 .build();
+							   .addWidget(powerDistributionPanelFrame)
+							   .addWidget(talonBox)
+							   .addWidget(victor1Box)
+							   .build();
 
 	const auto parentBox = BoxFactory(Gtk::ORIENTATION_VERTICAL, 5)
-						 .addWidget(controlsBox)
-						 .addWidget(sensorBox)
-						 .build();
+							   .addWidget(controlsBox)
+							   .addWidget(sensorBox)
+							   .build();
 
 	// Create the window
 	window = WindowFactory()


### PR DESCRIPTION
Adds a bounds check to parseType, so only the size of the variable it is being put into is being used. Can also be used to where it only grabs a few bytes instead of the whole size of the type it is being put into.

Also will always send data in little-endian form, no matter the endianness of the machine.

The communication of the robot and the client needs to be tested before merging.
